### PR TITLE
AMC Check forceAnime before forceSeries

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -183,10 +183,10 @@ def groups = input.groupBy{ f ->
 		return [music: f.dir.name]
 	if (forceMovie(f))
 		return [mov:   detectMovie(f, false)]
-	if (forceSeries(f))
-		return [tvs:   detectSeriesName(f, true, false) ?: detectSeriesName(f.dir.listFiles{ it.isVideo() }, true, false)]
 	if (forceAnime(f))
 		return [anime: detectSeriesName(f, false, true) ?: detectSeriesName(f.dir.listFiles{ it.isVideo() }, false, true)]
+	if (forceSeries(f))
+		return [tvs:   detectSeriesName(f, true, false) ?: detectSeriesName(f.dir.listFiles{ it.isVideo() }, true, false)]
 	
 	
 	def tvs = detectSeriesName(f, true, false)


### PR DESCRIPTION
Anime files are usually numbered by sequence (1,2,3...), however, sometimes I find torrents which number them by SxxExx.

The SxxExx numbering seems to make AMC think that its a TV Series rather than an Anime.

From looking at the checks that forceAnime runs, it seems very unlikely that it would return true on a TV series file, whereas there are cases that forceSeries returns true on Anime files.

Therefore, I propose for the amc.groovy script to check if the file is an Anime BEFORE checking if the file is a TV Series.
