### PR TITLE
Tell Plex to refresh only changed libraries

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -424,7 +424,20 @@ if (getRenameLog().size() > 0) {
 		plex.each{ host ->
 			log.info "Notify Plex: $host"
 			tryLogCatch {
-				refreshPlexLibrary(host)
+				groups.each { group, files ->
+					if (group.tvs || group.anime) {
+						log.info "Telling Plex to refresh TV shows"
+						refreshPlexLibrary(server:host, library:"show")
+					}
+					if (group.mov) {
+						log.info "Telling Plex to refresh movies"
+						refreshPlexLibrary(server:host, library:"movie")
+					}
+					if (group.music) {
+						log.info "Telling Plex to refresh music"
+						refreshPlexLibrary(server:host, library:"artist")
+					}
+				}
 			}
 		}
 	}

--- a/lib/htpc.groovy
+++ b/lib/htpc.groovy
@@ -25,9 +25,16 @@ def showNotification(host, port, title, message, image) {
 /**
  * Plex helpers
  */
-def refreshPlexLibrary(server, port = 32400) {
+def refreshPlexLibrary(Map m = [:]) {
 	tryLogCatch {
-		new URL("http://$server:$port/library/sections/all/refresh").get()
+		def defaultMap = ["server": "localhost", "port": 32400]
+		m = defaultMap << m
+		def (server, port, library) = [m["server"], m["port"], m["library"]]
+		new XmlSlurper().parse("http://$server:$port/library/sections").Directory.each { dir ->
+			if ("${dir.@type}" == library) {
+				new URL("http://$server:$port/library/sections/${dir.@key}/refresh").get()
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This could probably be a little smarter, but for me, at least, it works better than refreshing everything every time.
