### PR TITLE
Enhancement for Kodi hostname which supports now to define the HTTP port

### DIFF
--- a/lib/htpc.groovy
+++ b/lib/htpc.groovy
@@ -1,10 +1,11 @@
 
 /**
- * XBMC helper functions
+ * XBMC/Kodi helper functions
  */
 def scanVideoLibrary(host, port) {
 	def json = [jsonrpc: '2.0', method: 'VideoLibrary.Scan', id: 1]
-	def url = "http://$host:$port/jsonrpc?request=" + URLEncoder.encode(JsonOutput.toJson(json), 'UTF-8')
+	def hostAndPort = getHostAndPort(host, port)
+	def url = "http://$hostAndPort/jsonrpc?request=" + URLEncoder.encode(JsonOutput.toJson(json), 'UTF-8')
 
 	log.finest "GET: $url"
 	new URL(url).get()
@@ -12,12 +13,19 @@ def scanVideoLibrary(host, port) {
 
 def showNotification(host, port, title, message, image) {
 	def json = [jsonrpc:'2.0', method:'GUI.ShowNotification', params: [title: title, message: message, image: image], id: 1]
-	def url = "http://$host:$port/jsonrpc?request=" + URLEncoder.encode(JsonOutput.toJson(json), 'UTF-8')
+	def hostAndPort = getHostAndPort(host, port)
+	def url = "http://$hostAndPort/jsonrpc?request=" + URLEncoder.encode(JsonOutput.toJson(json), 'UTF-8')
 
 	log.finest "GET: $url"
 	new URL(url).get()
 }
 
+def getHostAndPort(hostWithPort, defaultPort) {
+    def hostAndPortSplitted = hostWithPort.split(/:/)
+    def hostOnly = hostAndPortSplitted[0];
+    def portOnly = (hostAndPortSplitted.length == 2) ? hostAndPortSplitted[1] : defaultPort;
+    return "$hostOnly:$portOnly"
+}
 
 
 /**


### PR DESCRIPTION
With your last change you've changed the way how you do the XBMC/Kodi video library refresh call - now you use HTTP (default port 8080/ user specific) and previously you used the JSON TCP protocoll (predefined port 9090) as mentioned at https://www.filebot.net/forums/viewtopic.php?t=4021

I've enhanced now the htpc.groovy script to support as Kodi host parameter a combination of `<userhost>:<userport>.` If the `<userport>` is not set then the default port, which is used while calling the XBMC/Kodi helper function e.g. in amc.groovy, is used to create the host:port target.

Example parameter definition on command line: 'xbmc=127.0.0.1:8083'