### PR TITLE
Allow scan in kodi even if showNotification failed

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -474,6 +474,8 @@ if (getRenameLog().size() > 0) {
 			log.info "Notify Kodi: ${instance.host}:${instance.port}"
 			tryLogCatch{
 				showNotification(instance.host, instance.port, getNotificationTitle(), getNotificationMessage(), 'http://app.filebot.net/icon.png')
+			}
+			tryLogCatch{
 				scanVideoLibrary(instance.host, instance.port)
 			}
 		}


### PR DESCRIPTION
sometime, showNotification failed for some reason (e.g. fileName too long). If showNotification and scanVideo are in the same try/catch, and showNotification failed, scan is not started.