### PR TITLE
Change subject of report emails

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -560,7 +560,7 @@ if (getRenameLog().size() > 0) {
 	}
 
 	// messages used for email / pushbullet reports
-	def getReportSubject = { getNotificationMessage('', ' | ') }
+	def getReportSubject = { getNotificationTitle('', ' | ') }
 	def getReportTitle = { '[FileBot] ' + getReportSubject() }
 	def getReportMessage = { 
 		def renameLog = getRenameLog()


### PR DESCRIPTION
Currently report emails list every single processed file in their subject, which just seems kind of silly. Changing from getNotificationMessage to getNotificationTitle should change the subject from, for example, "[FileBot] Lucifer.S02E08.1080p.WEB-DL.DD5.1.H.264-DRACULA | The.Grand.Tour.2016.S01E02.Operation.Desert.Stumble.1080p.AMZN.WEBRip.DD5.1.x264.Mooi1990" to "[FileBot] FileBot finished processing 2 files" which is a much more reasonable (and useful) subject line, IMO.