### PR TITLE
Remove [enableStartTLS: 'yes'] by default

### DIFF
--- a/lib/ant.groovy
+++ b/lib/ant.groovy
@@ -27,8 +27,6 @@ def sendmail(param) {
 	def sender    = param.remove('from')
 	def recipient = param.remove('to')
 
-	param << [enableStartTLS: 'yes']
-
 	tryLogCatch {
 		ant().mail(param) {
 			from(address: sender)


### PR DESCRIPTION
Tested and confirmed this to be the cause of the error:

"Failed to send email: Can't send command to SMTP host"

some users have been experiencing.