### PR TITLE
fix typo in htpc.groovy postKodiRPC() method

### DIFF
--- a/lib/htpc.groovy
+++ b/lib/htpc.groovy
@@ -13,7 +13,7 @@ def showNotification(host, port, title, message, image) {
 }
 
 def postKodiRPC(host, port, json) {
-	def url = "http://$host:$port/jsonrpc")
+	def url = "http://$host:$port/jsonrpc"
 	def bytes = JsonOutput.toJson(json).getBytes('UTF-8')
 
 	log.finest "POST: $url"


### PR DESCRIPTION
fixed typo related to this commit: b4c2e77bf22862c6b9050976b89b83e2f702237b
Use POST when invoking Kodi RPCs
@see https://www.filebot.net/forums/viewtopic.php?f=4&t=5446