### PR TITLE
Add some context if 0 files are processed.

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -716,5 +716,5 @@ if (clean) {
 
 
 if (destinationFiles.size() == 0) {
-	fail "Finished without processing any files"
+	fail "Finished without processing any files for $ut"
 }


### PR DESCRIPTION
If you get a mail only with the message "Finished without processing any files" you can't find out in which folder the error was .