### PR TITLE
Make API requests use https URL for thetvdb.com

### DIFF
--- a/lib/htpc.groovy
+++ b/lib/htpc.groovy
@@ -147,7 +147,7 @@ def fetchSeriesNfo(outputFile, i, locale) {
 			premiered(i.startDate)
 			status(i.status)
 			studio(i.network)
-			tvdb(id:i.id, 'http://www.thetvdb.com/?tab=series&id=' + i.id)
+			tvdb(id:i.id, 'https://www.thetvdb.com/?tab=series&id=' + i.id)
 			episodeguide {
 				url(post:'yes', cache:'auth.json', 'https://api.thetvdb.com/login?{"apikey":"439DFEBA9D3059C6","id":' + i.id + '}|Content-Type=application/json')
 			}


### PR DESCRIPTION
Since it is responding with an empty 301 response otherwise:
```
Fetch failed: http://thetvdb.com/api/GetSeries.php?seriesname=South+Park&language=en
net.filebot.InvalidResponseException: Invalid XML: SAXParseException: The element type "hr" must be terminated by the matching end-tag "</hr>".
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>CloudFront</center>
</body>
</html>

	at net.filebot.CachedResource.lambda$validateXml$5(CachedResource.java:173)
	at net.filebot.CachedResource.lambda$get$1(CachedResource.java:99)
	at net.filebot.Cache.computeIf(Cache.java:90)
	at net.filebot.CachedResource.get(CachedResource.java:82)
	at net.filebot.web.TheTVDBClientV1.getXmlResource(TheTVDBClientV1.java:269)
	at net.filebot.web.TheTVDBClientV1.fetchSearchResult(TheTVDBClientV1.java:86)
	at net.filebot.WebServices$TheTVDBClientWithLocalSearch.access$001(WebServices.java:129)
	at net.filebot.WebServices$TheTVDBClientWithLocalSearch.lambda$fetchSearchResult$4(WebServices.java:149)
Caused by: org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 3; The element type "hr" must be terminated by the matching end-tag "</hr>".
	at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:203)
	at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.fatalError(ErrorHandlerWrapper.java:177)
	at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:400)
	at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:327)
	at com.sun.org.apache.xerces.internal.impl.XMLScanner.reportFatalError(XMLScanner.java:1472)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanEndElement(XMLDocumentFragmentScannerImpl.java:1749)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2967)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:842)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:771)
	at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
	at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
	at net.filebot.web.WebRequest.validateXml(WebRequest.java:324)
	at net.filebot.CachedResource.lambda$validateXml$5(CachedResource.java:170)
	... 7 more

ExecutionException: net.filebot.InvalidResponseException: Invalid XML: SAXParseException: The element type "hr" must be terminated by the matching end-tag "</hr>".
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>CloudFront</center>
</body>
</html>

Finished without processing any files
```