### PR TITLE
Make subtitle fetching respect -non-strict mode

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -344,7 +344,7 @@ groups.each{ group, files ->
 	// fetch subtitles (but not for anime)
 	if ((group.isMovie() || group.isSeries()) && subtitles != null && files.findAll{ it.isVideo() }.size() > 0) {
 		subtitles.each{ languageCode ->
-			def subtitleFiles = getMissingSubtitles(file: files, lang: languageCode, strict: true, output: 'srt', encoding: 'UTF-8', format: 'MATCH_VIDEO_ADD_LANGUAGE_TAG') ?: []
+			def subtitleFiles = getMissingSubtitles(file: files, lang: languageCode, strict: _args.strict, output: 'srt', encoding: 'UTF-8', format: 'MATCH_VIDEO_ADD_LANGUAGE_TAG') ?: []
 			files += subtitleFiles
 			input += subtitleFiles // make sure subtitles are added to the exclude list and other post processing operations
 			temporaryFiles += subtitleFiles // if downloaded for temporarily extraced files delete later


### PR DESCRIPTION
Based on the documentation on the website (https://www.filebot.net/cli.html) fuzzy subtitle search is expected when the -non-strict argument is specified.

Discarding that, the amc scrpit should have a variable that allows name-based subtitle matching.