### PR TITLE
bug:ignore video extra eagerness

### DIFF
--- a/amc.groovy
+++ b/amc.groovy
@@ -220,7 +220,7 @@ def acceptFile(f) {
 		return false
 	}
 
-	if (f.isVideo() && f.name =~ /(?<=\b|_)(?i:Sample|Trailer|Extras|Featurettes|Extra.Episodes|Bonus.Features|Music.Video|Scrapbook|Behind.the.Scenes|Extended.Scenes|Deleted.Scenes|Mini.Series|s\d{2}c\d{2}|S\d+EXTRA|\d+xEXTRA|NCED|NCOP|(OP|ED)\d+|Formula.1.\d{4})(?=\b|_)/) {
+	if (f.isVideo() && f.name =~ /(?<=\b|_)(?i:Sample|Trailer(?!.park)|Extras|Featurettes|Extra.Episodes|Bonus.Features|Music.Video|Scrapbook|Behind.the.Scenes|Extended.Scenes|Deleted.Scenes|Mini.Series|s\d{2}c\d{2}|S\d+EXTRA|\d+xEXTRA|NCED|NCOP|(OP|ED)\d+|Formula.1.\d{4})(?=\b|_)/) {
 		log.finest "Ignore video extra: $f"
 		return false
 	}


### PR DESCRIPTION
The excerpt of the regex [ignore video extra](https://github.com/filebot/scripts/blob/master/amc.groovy#L223) inadvertently matches at least one known series "Trailer Park Boys"
```
Sample|Trailer|Extras
```
Using look ahead we can ignore files matching "trailer park". 
```
Sample|Trailer(?!.park)|Extras
```

This is quick fix.
